### PR TITLE
Fix type issues and included cstddef

### DIFF
--- a/header/CLZHashTable.h
+++ b/header/CLZHashTable.h
@@ -2,6 +2,7 @@
 #define CLZ_HASHTABLE_H
 
 #include <stack>
+#include <cstddef>
 
 class CLZHashTable {
 public:

--- a/source/CLZ.cpp
+++ b/source/CLZ.cpp
@@ -300,7 +300,7 @@ void CLZ::pack2(std::ifstream& infile, std::ofstream& outfile) {
   infile.seekg(0, std::ios::end);
   size_t decomp_size = infile.tellg();
   
-  char* array = new char[std::max(16u, decomp_size)];
+  char* array = new char[std::max(static_cast<size_t>(16), decomp_size)];
   
   array[0] = 'C';
   array[1] = 'L';
@@ -386,7 +386,7 @@ void CLZ::pack2(std::ifstream& infile, std::ofstream& outfile) {
       size_t hash = hashes[i % HASH_BUFFER_SIZE][j];
       size_t prev = hash_tables[j - 3].getLast(array, decomp_size, i, hash);
       if (prev != i) {
-        for (size_t t = std::max(longest, 2u); t < j; ++t) {
+        for (size_t t = std::max(longest, static_cast<size_t>(16)); t < j; ++t) {
           current_dlpairs[t] = i - prev;
         }
         longest = j;


### PR DESCRIPTION
Been playing around with HM:AWL files lately. I tried compiling your repo as is, but encountered errors when following your instructions. I was able to fix them with a few changes:
- Modified the argument types to match as size_t in CLZ.cpp.
- Included cstddef header file in CLZHashTable.h

I'm not particularly well versed in C++, but when I tested my modifications on a .clz file, the resulting .arc file had the correct U8 header. 